### PR TITLE
OpenTaskDialog component has been made. Only thing missing is proper …

### DIFF
--- a/src/components/CertaintyDialog.vue
+++ b/src/components/CertaintyDialog.vue
@@ -2,9 +2,8 @@
   <v-dialog v-model="dialog" persistent :max-width="400">
 
     <template v-slot:activator="{ on }">
-        <v-btn v-on="on">
+        <v-btn v-on="on" icon>
           <v-icon v-if="btnIcon"> {{ btnIcon }} </v-icon>
-          <span>{{ btnText }}</span> 
         </v-btn>
     </template>
 

--- a/src/components/OpenTaskDialog.vue
+++ b/src/components/OpenTaskDialog.vue
@@ -1,0 +1,136 @@
+<template>
+  <v-dialog v-model="openDialog" @click:outside="closeDialog">
+    <v-card>
+        <v-container>
+            
+            <v-row class="ma-0">
+              <v-card-title class="ma-0 pa-0"> {{ task.title }} </v-card-title>
+              <v-spacer></v-spacer>
+              <task-dialog :task="task" :updateBtn="true" buttonValue="mdi-pencil-outline"></task-dialog>
+            </v-row>
+
+            <v-divider color="#006685"></v-divider>
+
+            <v-row class="ma-0">
+              <p> {{ task.startTime }} - {{ task.finishTime }} </p>
+              <v-chip class="rounded-lg white--text" :color="returnCategory.color"> {{ returnCategory.name }} </v-chip>
+              <v-chip class="rounded-lg white--text" :color="returnEnergy.color"> {{ returnEnergy.level }} </v-chip>
+            </v-row>
+
+            <v-row class="ma-0" v-if="task.reminder">
+              <span>
+                <v-icon>mdi-bell</v-icon>
+                <p> {{ task.reminder }} </p>
+              </span>
+            </v-row>
+
+            <v-row class="ma-0" v-if="returnRepeat"> 
+              <v-icon>mdi-repeat</v-icon>
+              <p class="mb-0" v-if="task.repeat == 'Daglig'">Daglig</p>
+              <p class="mb-0" v-if="task.repeat == 'Ugentlig'">Ugentlig</p>
+            </v-row>
+
+            <v-col class="ma-0">
+              <v-card-subtitle class="ma-0 pa-0 font-italic">Trin</v-card-subtitle>
+              <v-row class="ma-0 ml-5" v-for="(step, index) in task.steps" :key="index">
+                <v-btn icon small outlined :color="step.done ? 'grey' : '#006685'" @click="stepDone(index, step.done)"><v-icon v-if="step.done">mdi-check</v-icon></v-btn>
+                <p :class="{ 'text-decoration-line-through': step.done}">{{ step.title }}</p>
+              </v-row>
+            </v-col>
+
+            <v-col v-if="task.note">
+              <v-card-subtitle class="ma-0 pa-0 font-italic">Note</v-card-subtitle>
+              <v-divider></v-divider>
+              <p>{{ task.note }}</p>
+            </v-col>
+
+            <v-row class="ma-0">
+              <v-btn outlined color="#006685" @click="closeDialog">Luk opgave</v-btn>
+              <certainty-dialog @confirmAsk="deleteTask" yesColor="red" noColor="#006685" btnIcon="mdi-trash-can-outline" title="Slet din opgave" subTitle="Er du sikker på du vil slette?"></certainty-dialog>
+            </v-row>
+
+        </v-container>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang='ts'>
+import { Task } from '@/lib/type';
+import { Component, Prop, Vue } from 'vue-property-decorator';
+import TaskDialog from '@/components/TaskDialog.vue';
+import CertaintyDialog from '@/components/CertaintyDialog.vue';
+
+@Component({
+  components: {
+    TaskDialog,
+    CertaintyDialog,
+  }
+})
+
+export default class OpenTaskDialog extends Vue {
+  @Prop({
+    required: true,
+  })
+  openDialog!: boolean;
+
+  @Prop({
+    required: true,
+  })
+  task!: Task;
+
+  deleteTask() {
+    this.closeDialog();
+    console.log('slet opgave');
+  }
+
+  closeDialog() {
+    this.$emit('closeDialog', false);
+  }
+
+  stepDone(index: number, done: boolean) {
+    this.$emit('stepDone', {index: index, done: !done}); // this should be changed for database update
+    console.log(index);
+  }
+
+  get returnCategory() {
+    if (this.task.category.color == undefined && this.task.category.name == undefined) {
+        return {
+          name: 'Ingen',
+          color: '#006685',
+        }
+    } else {
+        return {
+          name: this.task.category.name,
+          color: this.task.category.color,
+        }
+    }
+  }
+
+  get returnEnergy(): { color: string; level: string } {
+    if (this.task.energyOutcome == 'negative') {
+        return {
+          color: '#cd2026',
+          level: `- ${this.task.energyLevel}%`,
+        }
+    } else if (this.task.energyOutcome == 'positive') {
+        return {
+          color: '#2e8540',
+          level: `+ ${this.task.energyLevel}%`,
+        }
+    } else {
+        return {
+          color: '',
+          level: '',
+        }
+    }
+  }
+
+  get returnRepeat(): boolean {
+    if (this.task.repeat == 'Daglig' || this.task.repeat == 'Ugentlig') {
+      return true;
+    } else {
+      return false;
+    }
+  }
+}
+</script>

--- a/src/components/TaskCard.vue
+++ b/src/components/TaskCard.vue
@@ -85,16 +85,15 @@ export default class TaskCard extends Vue {
 
   /**
    * clickCheck changes the color and the done, and emits the boolean.
-   * 
-   * The button is supposed to turn back to false and change the color, if one wants that.
-   * Currently however it is not doing that. 
-   * 
-   * If you have any ideas on how to do this, please add it, and comment the 
    */
   clickCheck() {
-    this.done = true;
+    this.done = !this.done;
+    if (this.done == true) {
+      this.taskColor = 'grey';
+    } else {
+      this.taskColor = this.task.category.color ? this.task.category.color : '#006685';
+    }
     this.$emit('clickCheck', this.done);
-    this.taskColor = 'grey';
     // console.log(this.done);
     
   }
@@ -104,7 +103,7 @@ export default class TaskCard extends Vue {
    */
   clickCard() {
     this.$emit('clickCard', this.task);
-    console.log('klikket');
+    console.log(`klikket ${this.task.id}`);
   }
 
   /**

--- a/src/views/sandbox/Sandbox1.vue
+++ b/src/views/sandbox/Sandbox1.vue
@@ -8,7 +8,8 @@
     
     <task-dialog @handleTask="postTask" :updateBtn="true" buttonValue="mdi-pencil" :task="task"></task-dialog>
 
-    <task-card class="mb-7" @clickCheck="taskDone" :task="task"></task-card>
+    <task-card @clickCard="openDialog" class="mb-7" @clickCheck="taskDone" :task="task"></task-card>
+    <open-task-dialog @closeDialog="closeDialog" @stepDone="stepDone" :task="openTask" :openDialog="dialog"></open-task-dialog>
 
     <v-card class="pa-2" color="#006685">
       <energy-bar @energyIsLow="showText" :energySpend="60"></energy-bar>
@@ -27,6 +28,7 @@ import TaskDialog from '@/components/TaskDialog.vue';
 import { Task } from '@/lib/type';
 import TaskCard from '@/components/TaskCard.vue';
 import EnergyBar from '@/components/EnergyBar.vue';
+import OpenTaskDialog from '@/components/OpenTaskDialog.vue';
 
 @Component({
   components: {
@@ -34,6 +36,7 @@ import EnergyBar from '@/components/EnergyBar.vue';
     TaskDialog,
     TaskCard,
     EnergyBar,
+    OpenTaskDialog,
   }
 })
 
@@ -55,8 +58,8 @@ export default class Sandbox1 extends Vue {
       min: 1,
       hour: 6,
     },
-    repeat: 'Daglig',
-    date: 'daglig',
+    repeat: 'Ugentlig',
+    date: 'Mandag',
     category: {
       name: 'Arbejde',
       color: '#2196F3',
@@ -64,8 +67,24 @@ export default class Sandbox1 extends Vue {
     done: false,
   }
 
+  stepDone(step: { index: number; done: boolean}) {
+    this.task.steps[step.index].done = step.done;
+  }
+
   showWarning = false;
   colorIcon = '';
+
+  dialog = false;
+  openTask = {};
+  openDialog(task: Task) {
+    this.dialog = true;
+    this.openTask = task;
+    console.log(this.openTask);
+  }
+
+  closeDialog(close: boolean) {
+    this.dialog = close;
+  }
 
   showText(energy: { color: string; low: boolean }) {
     this.showWarning = energy.low;


### PR DESCRIPTION
…alignment of content, adding database stuff and adding the dialog to the Home view. The component requires two props the openDialog prop which opens the dialog and the task.

There are two emit but just one that will stay after database has been added. It is called closeDialog, and sends back a false, which closes the dialog.

That way the OpenTaskDialog can exist on Home view only one place, instead of adding it to every task there might be. The task can after all only be opened one at a time.

The TaskDialog was also added, and the certaintyDialog as well. These plus the steps and task checkmarks are the ones that are going to need to be hooked up to database.